### PR TITLE
Update Gradle Wrapper from 8.11.1 to 8.12

### DIFF
--- a/api/chrome-devtools-kotlin.api
+++ b/api/chrome-devtools-kotlin.api
@@ -81,6 +81,7 @@ public final class org/hildan/chrome/devtools/domains/accessibility/AXProperty$C
 
 public final class org/hildan/chrome/devtools/domains/accessibility/AXPropertyName : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/accessibility/AXPropertyName$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/accessibility/AXPropertyName;
 	public static final field actions Lorg/hildan/chrome/devtools/domains/accessibility/AXPropertyName;
 	public static final field activedescendant Lorg/hildan/chrome/devtools/domains/accessibility/AXPropertyName;
 	public static final field atomic Lorg/hildan/chrome/devtools/domains/accessibility/AXPropertyName;
@@ -199,6 +200,7 @@ public final class org/hildan/chrome/devtools/domains/accessibility/AXValue$Comp
 
 public final class org/hildan/chrome/devtools/domains/accessibility/AXValueNativeSourceType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/accessibility/AXValueNativeSourceType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/accessibility/AXValueNativeSourceType;
 	public static final field description Lorg/hildan/chrome/devtools/domains/accessibility/AXValueNativeSourceType;
 	public static final field figcaption Lorg/hildan/chrome/devtools/domains/accessibility/AXValueNativeSourceType;
 	public static final field label Lorg/hildan/chrome/devtools/domains/accessibility/AXValueNativeSourceType;
@@ -264,6 +266,7 @@ public final class org/hildan/chrome/devtools/domains/accessibility/AXValueSourc
 
 public final class org/hildan/chrome/devtools/domains/accessibility/AXValueSourceType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/accessibility/AXValueSourceType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/accessibility/AXValueSourceType;
 	public static final field attribute Lorg/hildan/chrome/devtools/domains/accessibility/AXValueSourceType;
 	public static final field contents Lorg/hildan/chrome/devtools/domains/accessibility/AXValueSourceType;
 	public static final field implicit Lorg/hildan/chrome/devtools/domains/accessibility/AXValueSourceType;
@@ -281,6 +284,7 @@ public final class org/hildan/chrome/devtools/domains/accessibility/AXValueSourc
 
 public final class org/hildan/chrome/devtools/domains/accessibility/AXValueType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/accessibility/AXValueType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/accessibility/AXValueType;
 	public static final field boolean Lorg/hildan/chrome/devtools/domains/accessibility/AXValueType;
 	public static final field booleanOrUndefined Lorg/hildan/chrome/devtools/domains/accessibility/AXValueType;
 	public static final field computedString Lorg/hildan/chrome/devtools/domains/accessibility/AXValueType;
@@ -962,6 +966,7 @@ public final class org/hildan/chrome/devtools/domains/animation/AnimationType : 
 	public static final field CSSAnimation Lorg/hildan/chrome/devtools/domains/animation/AnimationType;
 	public static final field CSSTransition Lorg/hildan/chrome/devtools/domains/animation/AnimationType;
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/animation/AnimationType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/animation/AnimationType;
 	public static final field WebAnimation Lorg/hildan/chrome/devtools/domains/animation/AnimationType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/animation/AnimationType;
@@ -1641,6 +1646,7 @@ public final class org/hildan/chrome/devtools/domains/audits/AttributionReportin
 	public static final field SourceAndTriggerHeaders Lorg/hildan/chrome/devtools/domains/audits/AttributionReportingIssueType;
 	public static final field SourceIgnored Lorg/hildan/chrome/devtools/domains/audits/AttributionReportingIssueType;
 	public static final field TriggerIgnored Lorg/hildan/chrome/devtools/domains/audits/AttributionReportingIssueType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/AttributionReportingIssueType;
 	public static final field UntrustworthyReportingOrigin Lorg/hildan/chrome/devtools/domains/audits/AttributionReportingIssueType;
 	public static final field WebAndOsHeaders Lorg/hildan/chrome/devtools/domains/audits/AttributionReportingIssueType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -1713,6 +1719,7 @@ public final class org/hildan/chrome/devtools/domains/audits/BlockedByResponseRe
 	public static final field CorpNotSameOriginAfterDefaultedToSameOriginByDip Lorg/hildan/chrome/devtools/domains/audits/BlockedByResponseReason;
 	public static final field CorpNotSameSite Lorg/hildan/chrome/devtools/domains/audits/BlockedByResponseReason;
 	public static final field SRIMessageSignatureMismatch Lorg/hildan/chrome/devtools/domains/audits/BlockedByResponseReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/BlockedByResponseReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/BlockedByResponseReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/BlockedByResponseReason;
@@ -1850,6 +1857,7 @@ public final class org/hildan/chrome/devtools/domains/audits/ClientHintIssueReas
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/ClientHintIssueReason$Companion;
 	public static final field MetaTagAllowListInvalidOrigin Lorg/hildan/chrome/devtools/domains/audits/ClientHintIssueReason;
 	public static final field MetaTagModifiedHTML Lorg/hildan/chrome/devtools/domains/audits/ClientHintIssueReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/ClientHintIssueReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/ClientHintIssueReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/ClientHintIssueReason;
@@ -1901,6 +1909,7 @@ public final class org/hildan/chrome/devtools/domains/audits/ContentSecurityPoli
 
 public final class org/hildan/chrome/devtools/domains/audits/ContentSecurityPolicyViolationType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/ContentSecurityPolicyViolationType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/ContentSecurityPolicyViolationType;
 	public static final field kEvalViolation Lorg/hildan/chrome/devtools/domains/audits/ContentSecurityPolicyViolationType;
 	public static final field kInlineViolation Lorg/hildan/chrome/devtools/domains/audits/ContentSecurityPolicyViolationType;
 	public static final field kTrustedTypesPolicyViolation Lorg/hildan/chrome/devtools/domains/audits/ContentSecurityPolicyViolationType;
@@ -1962,6 +1971,7 @@ public final class org/hildan/chrome/devtools/domains/audits/CookieExclusionReas
 	public static final field ExcludeSchemeMismatch Lorg/hildan/chrome/devtools/domains/audits/CookieExclusionReason;
 	public static final field ExcludeThirdPartyCookieBlockedInFirstPartySet Lorg/hildan/chrome/devtools/domains/audits/CookieExclusionReason;
 	public static final field ExcludeThirdPartyPhaseout Lorg/hildan/chrome/devtools/domains/audits/CookieExclusionReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/CookieExclusionReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/CookieExclusionReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/CookieExclusionReason;
@@ -2049,6 +2059,7 @@ public final class org/hildan/chrome/devtools/domains/audits/CookieOperation : j
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/CookieOperation$Companion;
 	public static final field ReadCookie Lorg/hildan/chrome/devtools/domains/audits/CookieOperation;
 	public static final field SetCookie Lorg/hildan/chrome/devtools/domains/audits/CookieOperation;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/CookieOperation;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/CookieOperation;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/CookieOperation;
@@ -2060,6 +2071,7 @@ public final class org/hildan/chrome/devtools/domains/audits/CookieOperation$Com
 
 public final class org/hildan/chrome/devtools/domains/audits/CookieWarningReason : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/CookieWarningReason$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/CookieWarningReason;
 	public static final field WarnAttributeValueExceedsMaxSize Lorg/hildan/chrome/devtools/domains/audits/CookieWarningReason;
 	public static final field WarnCrossSiteRedirectDowngradeChangesInclusion Lorg/hildan/chrome/devtools/domains/audits/CookieWarningReason;
 	public static final field WarnDeprecationTrialMetadata Lorg/hildan/chrome/devtools/domains/audits/CookieWarningReason;
@@ -2167,6 +2179,7 @@ public final class org/hildan/chrome/devtools/domains/audits/EnableResponse {
 
 public final class org/hildan/chrome/devtools/domains/audits/EncodedResponseEncoding : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/EncodedResponseEncoding$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/EncodedResponseEncoding;
 	public static final field jpeg Lorg/hildan/chrome/devtools/domains/audits/EncodedResponseEncoding;
 	public static final field png Lorg/hildan/chrome/devtools/domains/audits/EncodedResponseEncoding;
 	public static final field webp Lorg/hildan/chrome/devtools/domains/audits/EncodedResponseEncoding;
@@ -2279,6 +2292,7 @@ public final class org/hildan/chrome/devtools/domains/audits/FederatedAuthReques
 	public static final field ThirdPartyCookiesBlocked Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
 	public static final field TooManyRequests Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
 	public static final field TypeNotMatching Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
 	public static final field WellKnownHttpNotFound Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
 	public static final field WellKnownInvalidContentType Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
 	public static final field WellKnownInvalidResponse Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthRequestIssueReason;
@@ -2332,6 +2346,7 @@ public final class org/hildan/chrome/devtools/domains/audits/FederatedAuthUserIn
 	public static final field NotPotentiallyTrustworthy Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthUserInfoRequestIssueReason;
 	public static final field NotSameOrigin Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthUserInfoRequestIssueReason;
 	public static final field NotSignedInWithIdp Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthUserInfoRequestIssueReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthUserInfoRequestIssueReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthUserInfoRequestIssueReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/FederatedAuthUserInfoRequestIssueReason;
@@ -2390,6 +2405,7 @@ public final class org/hildan/chrome/devtools/domains/audits/GenericIssueErrorTy
 	public static final field FormLabelForNameError Lorg/hildan/chrome/devtools/domains/audits/GenericIssueErrorType;
 	public static final field FormLabelHasNeitherForNorNestedInput Lorg/hildan/chrome/devtools/domains/audits/GenericIssueErrorType;
 	public static final field ResponseWasBlockedByORB Lorg/hildan/chrome/devtools/domains/audits/GenericIssueErrorType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/GenericIssueErrorType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/GenericIssueErrorType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/GenericIssueErrorType;
@@ -2512,6 +2528,7 @@ public final class org/hildan/chrome/devtools/domains/audits/HeavyAdReason : jav
 	public static final field CpuPeakLimit Lorg/hildan/chrome/devtools/domains/audits/HeavyAdReason;
 	public static final field CpuTotalLimit Lorg/hildan/chrome/devtools/domains/audits/HeavyAdReason;
 	public static final field NetworkTotalLimit Lorg/hildan/chrome/devtools/domains/audits/HeavyAdReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/HeavyAdReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/HeavyAdReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/HeavyAdReason;
@@ -2525,6 +2542,7 @@ public final class org/hildan/chrome/devtools/domains/audits/HeavyAdResolutionSt
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/HeavyAdResolutionStatus$Companion;
 	public static final field HeavyAdBlocked Lorg/hildan/chrome/devtools/domains/audits/HeavyAdResolutionStatus;
 	public static final field HeavyAdWarning Lorg/hildan/chrome/devtools/domains/audits/HeavyAdResolutionStatus;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/HeavyAdResolutionStatus;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/HeavyAdResolutionStatus;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/HeavyAdResolutionStatus;
@@ -2539,6 +2557,7 @@ public final class org/hildan/chrome/devtools/domains/audits/InsightType : java/
 	public static final field GitHubResource Lorg/hildan/chrome/devtools/domains/audits/InsightType;
 	public static final field GracePeriod Lorg/hildan/chrome/devtools/domains/audits/InsightType;
 	public static final field Heuristics Lorg/hildan/chrome/devtools/domains/audits/InsightType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/InsightType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/InsightType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/InsightType;
@@ -2603,6 +2622,7 @@ public final class org/hildan/chrome/devtools/domains/audits/InspectorIssueCode 
 	public static final field SharedArrayBufferIssue Lorg/hildan/chrome/devtools/domains/audits/InspectorIssueCode;
 	public static final field SharedDictionaryIssue Lorg/hildan/chrome/devtools/domains/audits/InspectorIssueCode;
 	public static final field StylesheetLoadingIssue Lorg/hildan/chrome/devtools/domains/audits/InspectorIssueCode;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/InspectorIssueCode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/InspectorIssueCode;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/InspectorIssueCode;
@@ -2763,6 +2783,7 @@ public final class org/hildan/chrome/devtools/domains/audits/MixedContentResolut
 	public static final field MixedContentAutomaticallyUpgraded Lorg/hildan/chrome/devtools/domains/audits/MixedContentResolutionStatus;
 	public static final field MixedContentBlocked Lorg/hildan/chrome/devtools/domains/audits/MixedContentResolutionStatus;
 	public static final field MixedContentWarning Lorg/hildan/chrome/devtools/domains/audits/MixedContentResolutionStatus;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/MixedContentResolutionStatus;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/MixedContentResolutionStatus;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/MixedContentResolutionStatus;
@@ -2799,6 +2820,7 @@ public final class org/hildan/chrome/devtools/domains/audits/MixedContentResourc
 	public static final field SpeculationRules Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
 	public static final field Stylesheet Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
 	public static final field Track Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
 	public static final field Video Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
 	public static final field Worker Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
 	public static final field XMLHttpRequest Lorg/hildan/chrome/devtools/domains/audits/MixedContentResourceType;
@@ -2880,6 +2902,7 @@ public final class org/hildan/chrome/devtools/domains/audits/PropertyRuleIssueRe
 	public static final field InvalidInitialValue Lorg/hildan/chrome/devtools/domains/audits/PropertyRuleIssueReason;
 	public static final field InvalidName Lorg/hildan/chrome/devtools/domains/audits/PropertyRuleIssueReason;
 	public static final field InvalidSyntax Lorg/hildan/chrome/devtools/domains/audits/PropertyRuleIssueReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/PropertyRuleIssueReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/PropertyRuleIssueReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/PropertyRuleIssueReason;
@@ -2959,6 +2982,7 @@ public final class org/hildan/chrome/devtools/domains/audits/SharedArrayBufferIs
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/SharedArrayBufferIssueType$Companion;
 	public static final field CreationIssue Lorg/hildan/chrome/devtools/domains/audits/SharedArrayBufferIssueType;
 	public static final field TransferIssue Lorg/hildan/chrome/devtools/domains/audits/SharedArrayBufferIssueType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/SharedArrayBufferIssueType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/SharedArrayBufferIssueType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/SharedArrayBufferIssueType;
@@ -2970,6 +2994,7 @@ public final class org/hildan/chrome/devtools/domains/audits/SharedArrayBufferIs
 
 public final class org/hildan/chrome/devtools/domains/audits/SharedDictionaryError : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/SharedDictionaryError$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/SharedDictionaryError;
 	public static final field UseErrorCrossOriginNoCorsRequest Lorg/hildan/chrome/devtools/domains/audits/SharedDictionaryError;
 	public static final field UseErrorDictionaryLoadFailure Lorg/hildan/chrome/devtools/domains/audits/SharedDictionaryError;
 	public static final field UseErrorMatchingDictionaryNotUsed Lorg/hildan/chrome/devtools/domains/audits/SharedDictionaryError;
@@ -3069,6 +3094,7 @@ public final class org/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIs
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIssueReason$Companion;
 	public static final field LateImportRule Lorg/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIssueReason;
 	public static final field RequestFailed Lorg/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIssueReason;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIssueReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIssueReason;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/audits/StyleSheetLoadingIssueReason;
@@ -3359,6 +3385,7 @@ public final class org/hildan/chrome/devtools/domains/autofill/FilledField$Compa
 
 public final class org/hildan/chrome/devtools/domains/autofill/FillingStrategy : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/autofill/FillingStrategy$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/autofill/FillingStrategy;
 	public static final field autocompleteAttribute Lorg/hildan/chrome/devtools/domains/autofill/FillingStrategy;
 	public static final field autofillInferred Lorg/hildan/chrome/devtools/domains/autofill/FillingStrategy;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -3607,6 +3634,7 @@ public final class org/hildan/chrome/devtools/domains/backgroundservice/EventMet
 
 public final class org/hildan/chrome/devtools/domains/backgroundservice/ServiceName : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/backgroundservice/ServiceName$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/backgroundservice/ServiceName;
 	public static final field backgroundFetch Lorg/hildan/chrome/devtools/domains/backgroundservice/ServiceName;
 	public static final field backgroundSync Lorg/hildan/chrome/devtools/domains/backgroundservice/ServiceName;
 	public static final field notifications Lorg/hildan/chrome/devtools/domains/backgroundservice/ServiceName;
@@ -3798,6 +3826,7 @@ public final class org/hildan/chrome/devtools/domains/bluetoothemulation/Bluetoo
 
 public final class org/hildan/chrome/devtools/domains/bluetoothemulation/CentralState : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/bluetoothemulation/CentralState$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/bluetoothemulation/CentralState;
 	public static final field absent Lorg/hildan/chrome/devtools/domains/bluetoothemulation/CentralState;
 	public static final field poweredOff Lorg/hildan/chrome/devtools/domains/bluetoothemulation/CentralState;
 	public static final field poweredOn Lorg/hildan/chrome/devtools/domains/bluetoothemulation/CentralState;
@@ -5189,6 +5218,7 @@ public final class org/hildan/chrome/devtools/domains/cachestorage/CachedRespons
 
 public final class org/hildan/chrome/devtools/domains/cachestorage/CachedResponseType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/cachestorage/CachedResponseType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/cachestorage/CachedResponseType;
 	public static final field basic Lorg/hildan/chrome/devtools/domains/cachestorage/CachedResponseType;
 	public static final field cors Lorg/hildan/chrome/devtools/domains/cachestorage/CachedResponseType;
 	public static final field default Lorg/hildan/chrome/devtools/domains/cachestorage/CachedResponseType;
@@ -6392,6 +6422,7 @@ public final class org/hildan/chrome/devtools/domains/css/CSSMedia$Companion {
 
 public final class org/hildan/chrome/devtools/domains/css/CSSMediaSource : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/css/CSSMediaSource$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/css/CSSMediaSource;
 	public static final field importRule Lorg/hildan/chrome/devtools/domains/css/CSSMediaSource;
 	public static final field inlineSheet Lorg/hildan/chrome/devtools/domains/css/CSSMediaSource;
 	public static final field linkedSheet Lorg/hildan/chrome/devtools/domains/css/CSSMediaSource;
@@ -6612,6 +6643,7 @@ public final class org/hildan/chrome/devtools/domains/css/CSSRuleType : java/lan
 	public static final field StartingStyleRule Lorg/hildan/chrome/devtools/domains/css/CSSRuleType;
 	public static final field StyleRule Lorg/hildan/chrome/devtools/domains/css/CSSRuleType;
 	public static final field SupportsRule Lorg/hildan/chrome/devtools/domains/css/CSSRuleType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/css/CSSRuleType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/css/CSSRuleType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/css/CSSRuleType;
@@ -8614,6 +8646,7 @@ public final class org/hildan/chrome/devtools/domains/css/StyleDeclarationEdit$C
 
 public final class org/hildan/chrome/devtools/domains/css/StyleSheetOrigin : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/css/StyleSheetOrigin$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/css/StyleSheetOrigin;
 	public static final field injected Lorg/hildan/chrome/devtools/domains/css/StyleSheetOrigin;
 	public static final field inspector Lorg/hildan/chrome/devtools/domains/css/StyleSheetOrigin;
 	public static final field regular Lorg/hildan/chrome/devtools/domains/css/StyleSheetOrigin;
@@ -19043,6 +19076,7 @@ public final class org/hildan/chrome/devtools/domains/extensions/SetStorageItems
 
 public final class org/hildan/chrome/devtools/domains/extensions/StorageArea : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/extensions/StorageArea$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/extensions/StorageArea;
 	public static final field local Lorg/hildan/chrome/devtools/domains/extensions/StorageArea;
 	public static final field managed Lorg/hildan/chrome/devtools/domains/extensions/StorageArea;
 	public static final field session Lorg/hildan/chrome/devtools/domains/extensions/StorageArea;
@@ -19106,6 +19140,7 @@ public final class org/hildan/chrome/devtools/domains/fedcm/AccountUrlType : jav
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/fedcm/AccountUrlType$Companion;
 	public static final field PrivacyPolicy Lorg/hildan/chrome/devtools/domains/fedcm/AccountUrlType;
 	public static final field TermsOfService Lorg/hildan/chrome/devtools/domains/fedcm/AccountUrlType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/fedcm/AccountUrlType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/fedcm/AccountUrlType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/fedcm/AccountUrlType;
@@ -19154,6 +19189,7 @@ public final class org/hildan/chrome/devtools/domains/fedcm/DialogButton : java/
 	public static final field ConfirmIdpLoginContinue Lorg/hildan/chrome/devtools/domains/fedcm/DialogButton;
 	public static final field ErrorGotIt Lorg/hildan/chrome/devtools/domains/fedcm/DialogButton;
 	public static final field ErrorMoreDetails Lorg/hildan/chrome/devtools/domains/fedcm/DialogButton;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/fedcm/DialogButton;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/fedcm/DialogButton;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/fedcm/DialogButton;
@@ -19169,6 +19205,7 @@ public final class org/hildan/chrome/devtools/domains/fedcm/DialogType : java/la
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/fedcm/DialogType$Companion;
 	public static final field ConfirmIdpLogin Lorg/hildan/chrome/devtools/domains/fedcm/DialogType;
 	public static final field Error Lorg/hildan/chrome/devtools/domains/fedcm/DialogType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/fedcm/DialogType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/fedcm/DialogType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/fedcm/DialogType;
@@ -19295,6 +19332,7 @@ public final class org/hildan/chrome/devtools/domains/fedcm/LoginState : java/la
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/fedcm/LoginState$Companion;
 	public static final field SignIn Lorg/hildan/chrome/devtools/domains/fedcm/LoginState;
 	public static final field SignUp Lorg/hildan/chrome/devtools/domains/fedcm/LoginState;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/fedcm/LoginState;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/fedcm/LoginState;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/fedcm/LoginState;
@@ -20398,6 +20436,7 @@ public final class org/hildan/chrome/devtools/domains/headlessexperimental/Headl
 
 public final class org/hildan/chrome/devtools/domains/headlessexperimental/ImageFormat : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/headlessexperimental/ImageFormat$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/headlessexperimental/ImageFormat;
 	public static final field jpeg Lorg/hildan/chrome/devtools/domains/headlessexperimental/ImageFormat;
 	public static final field png Lorg/hildan/chrome/devtools/domains/headlessexperimental/ImageFormat;
 	public static final field webp Lorg/hildan/chrome/devtools/domains/headlessexperimental/ImageFormat;
@@ -21540,6 +21579,7 @@ public final class org/hildan/chrome/devtools/domains/indexeddb/KeyPath$Companio
 
 public final class org/hildan/chrome/devtools/domains/indexeddb/KeyPathType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/indexeddb/KeyPathType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/indexeddb/KeyPathType;
 	public static final field array Lorg/hildan/chrome/devtools/domains/indexeddb/KeyPathType;
 	public static final field null Lorg/hildan/chrome/devtools/domains/indexeddb/KeyPathType;
 	public static final field string Lorg/hildan/chrome/devtools/domains/indexeddb/KeyPathType;
@@ -21588,6 +21628,7 @@ public final class org/hildan/chrome/devtools/domains/indexeddb/KeyRange$Compani
 
 public final class org/hildan/chrome/devtools/domains/indexeddb/KeyType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/indexeddb/KeyType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/indexeddb/KeyType;
 	public static final field array Lorg/hildan/chrome/devtools/domains/indexeddb/KeyType;
 	public static final field date Lorg/hildan/chrome/devtools/domains/indexeddb/KeyType;
 	public static final field number Lorg/hildan/chrome/devtools/domains/indexeddb/KeyType;
@@ -23660,6 +23701,7 @@ public final class org/hildan/chrome/devtools/domains/layertree/ScrollRectType :
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/layertree/ScrollRectType$Companion;
 	public static final field RepaintsOnScroll Lorg/hildan/chrome/devtools/domains/layertree/ScrollRectType;
 	public static final field TouchEventHandler Lorg/hildan/chrome/devtools/domains/layertree/ScrollRectType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/layertree/ScrollRectType;
 	public static final field WheelEventHandler Lorg/hildan/chrome/devtools/domains/layertree/ScrollRectType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/layertree/ScrollRectType;
@@ -24223,6 +24265,7 @@ public final class org/hildan/chrome/devtools/domains/media/PlayerMessage$Compan
 
 public final class org/hildan/chrome/devtools/domains/media/PlayerMessageLevel : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/media/PlayerMessageLevel$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/media/PlayerMessageLevel;
 	public static final field debug Lorg/hildan/chrome/devtools/domains/media/PlayerMessageLevel;
 	public static final field error Lorg/hildan/chrome/devtools/domains/media/PlayerMessageLevel;
 	public static final field info Lorg/hildan/chrome/devtools/domains/media/PlayerMessageLevel;
@@ -24650,6 +24693,7 @@ public final class org/hildan/chrome/devtools/domains/memory/PrepareForLeakDetec
 
 public final class org/hildan/chrome/devtools/domains/memory/PressureLevel : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/memory/PressureLevel$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/memory/PressureLevel;
 	public static final field critical Lorg/hildan/chrome/devtools/domains/memory/PressureLevel;
 	public static final field moderate Lorg/hildan/chrome/devtools/domains/memory/PressureLevel;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -29501,6 +29545,7 @@ public final class org/hildan/chrome/devtools/domains/overlay/BoxStyle$Companion
 
 public final class org/hildan/chrome/devtools/domains/overlay/ColorFormat : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/overlay/ColorFormat$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/overlay/ColorFormat;
 	public static final field hex Lorg/hildan/chrome/devtools/domains/overlay/ColorFormat;
 	public static final field hsl Lorg/hildan/chrome/devtools/domains/overlay/ColorFormat;
 	public static final field hwb Lorg/hildan/chrome/devtools/domains/overlay/ColorFormat;
@@ -29576,6 +29621,7 @@ public final class org/hildan/chrome/devtools/domains/overlay/ContainerQueryHigh
 
 public final class org/hildan/chrome/devtools/domains/overlay/ContrastAlgorithm : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/overlay/ContrastAlgorithm$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/overlay/ContrastAlgorithm;
 	public static final field aa Lorg/hildan/chrome/devtools/domains/overlay/ContrastAlgorithm;
 	public static final field aaa Lorg/hildan/chrome/devtools/domains/overlay/ContrastAlgorithm;
 	public static final field apca Lorg/hildan/chrome/devtools/domains/overlay/ContrastAlgorithm;
@@ -30344,6 +30390,7 @@ public final class org/hildan/chrome/devtools/domains/overlay/HingeConfig$Compan
 
 public final class org/hildan/chrome/devtools/domains/overlay/InspectMode : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/overlay/InspectMode$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/overlay/InspectMode;
 	public static final field captureAreaScreenshot Lorg/hildan/chrome/devtools/domains/overlay/InspectMode;
 	public static final field none Lorg/hildan/chrome/devtools/domains/overlay/InspectMode;
 	public static final field searchForNode Lorg/hildan/chrome/devtools/domains/overlay/InspectMode;
@@ -30453,6 +30500,7 @@ public final class org/hildan/chrome/devtools/domains/overlay/LineStyle$Companio
 
 public final class org/hildan/chrome/devtools/domains/overlay/LineStylePattern : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/overlay/LineStylePattern$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/overlay/LineStylePattern;
 	public static final field dashed Lorg/hildan/chrome/devtools/domains/overlay/LineStylePattern;
 	public static final field dotted Lorg/hildan/chrome/devtools/domains/overlay/LineStylePattern;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -37004,6 +37052,7 @@ public final class org/hildan/chrome/devtools/domains/preload/PrefetchStatus : j
 	public static final field PrefetchProxyNotAvailable Lorg/hildan/chrome/devtools/domains/preload/PrefetchStatus;
 	public static final field PrefetchResponseUsed Lorg/hildan/chrome/devtools/domains/preload/PrefetchStatus;
 	public static final field PrefetchSuccessfulButNotUsed Lorg/hildan/chrome/devtools/domains/preload/PrefetchStatus;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/preload/PrefetchStatus;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/preload/PrefetchStatus;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/preload/PrefetchStatus;
@@ -37104,6 +37153,7 @@ public final class org/hildan/chrome/devtools/domains/preload/PreloadingStatus :
 	public static final field Ready Lorg/hildan/chrome/devtools/domains/preload/PreloadingStatus;
 	public static final field Running Lorg/hildan/chrome/devtools/domains/preload/PreloadingStatus;
 	public static final field Success Lorg/hildan/chrome/devtools/domains/preload/PreloadingStatus;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/preload/PreloadingStatus;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/preload/PreloadingStatus;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/preload/PreloadingStatus;
@@ -37185,6 +37235,7 @@ public final class org/hildan/chrome/devtools/domains/preload/PrerenderFinalStat
 	public static final field TriggerBackgrounded Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
 	public static final field TriggerDestroyed Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
 	public static final field TriggerUrlHasEffectiveUrl Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
 	public static final field UaChangeRequiresReload Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
 	public static final field V8OptimizerDisabled Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
 	public static final field WindowClosed Lorg/hildan/chrome/devtools/domains/preload/PrerenderFinalStatus;
@@ -37275,6 +37326,7 @@ public final class org/hildan/chrome/devtools/domains/preload/RuleSetErrorType :
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/preload/RuleSetErrorType$Companion;
 	public static final field InvalidRulesSkipped Lorg/hildan/chrome/devtools/domains/preload/RuleSetErrorType;
 	public static final field SourceIsNotJsonObject Lorg/hildan/chrome/devtools/domains/preload/RuleSetErrorType;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/preload/RuleSetErrorType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/preload/RuleSetErrorType;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/preload/RuleSetErrorType;
@@ -37288,6 +37340,7 @@ public final class org/hildan/chrome/devtools/domains/preload/SpeculationAction 
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/preload/SpeculationAction$Companion;
 	public static final field Prefetch Lorg/hildan/chrome/devtools/domains/preload/SpeculationAction;
 	public static final field Prerender Lorg/hildan/chrome/devtools/domains/preload/SpeculationAction;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/preload/SpeculationAction;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/preload/SpeculationAction;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/preload/SpeculationAction;
@@ -37301,6 +37354,7 @@ public final class org/hildan/chrome/devtools/domains/preload/SpeculationTargetH
 	public static final field Blank Lorg/hildan/chrome/devtools/domains/preload/SpeculationTargetHint;
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/preload/SpeculationTargetHint$Companion;
 	public static final field Self Lorg/hildan/chrome/devtools/domains/preload/SpeculationTargetHint;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/preload/SpeculationTargetHint;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hildan/chrome/devtools/domains/preload/SpeculationTargetHint;
 	public static fun values ()[Lorg/hildan/chrome/devtools/domains/preload/SpeculationTargetHint;
@@ -38092,6 +38146,7 @@ public final class org/hildan/chrome/devtools/domains/pwa/ChangeAppUserSettingsR
 
 public final class org/hildan/chrome/devtools/domains/pwa/DisplayMode : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/pwa/DisplayMode$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/pwa/DisplayMode;
 	public static final field browser Lorg/hildan/chrome/devtools/domains/pwa/DisplayMode;
 	public static final field standalone Lorg/hildan/chrome/devtools/domains/pwa/DisplayMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -41500,6 +41555,7 @@ public final class org/hildan/chrome/devtools/domains/serviceworker/ServiceWorke
 
 public final class org/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionRunningStatus : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionRunningStatus$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionRunningStatus;
 	public static final field running Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionRunningStatus;
 	public static final field starting Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionRunningStatus;
 	public static final field stopped Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionRunningStatus;
@@ -41515,6 +41571,7 @@ public final class org/hildan/chrome/devtools/domains/serviceworker/ServiceWorke
 
 public final class org/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionStatus : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionStatus$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionStatus;
 	public static final field activated Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionStatus;
 	public static final field activating Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionStatus;
 	public static final field installed Lorg/hildan/chrome/devtools/domains/serviceworker/ServiceWorkerVersionStatus;
@@ -41915,6 +41972,7 @@ public final class org/hildan/chrome/devtools/domains/storage/AttributionReporti
 
 public final class org/hildan/chrome/devtools/domains/storage/AttributionReportingAggregatableResult : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingAggregatableResult$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingAggregatableResult;
 	public static final field deduplicated Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingAggregatableResult;
 	public static final field excessiveAttributions Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingAggregatableResult;
 	public static final field excessiveReportingOrigins Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingAggregatableResult;
@@ -42061,6 +42119,7 @@ public final class org/hildan/chrome/devtools/domains/storage/AttributionReporti
 
 public final class org/hildan/chrome/devtools/domains/storage/AttributionReportingEventLevelResult : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingEventLevelResult$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingEventLevelResult;
 	public static final field deduplicated Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingEventLevelResult;
 	public static final field excessiveAttributions Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingEventLevelResult;
 	public static final field excessiveReportingOrigins Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingEventLevelResult;
@@ -42304,6 +42363,7 @@ public final class org/hildan/chrome/devtools/domains/storage/AttributionReporti
 
 public final class org/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationResult : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationResult$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationResult;
 	public static final field destinationBothLimitsReached Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationResult;
 	public static final field destinationGlobalLimitReached Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationResult;
 	public static final field destinationPerDayReportingLimitReached Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationResult;
@@ -42331,6 +42391,7 @@ public final class org/hildan/chrome/devtools/domains/storage/AttributionReporti
 
 public final class org/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationTimeConfig : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationTimeConfig$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationTimeConfig;
 	public static final field exclude Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationTimeConfig;
 	public static final field include Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceRegistrationTimeConfig;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -42344,6 +42405,7 @@ public final class org/hildan/chrome/devtools/domains/storage/AttributionReporti
 
 public final class org/hildan/chrome/devtools/domains/storage/AttributionReportingSourceType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceType;
 	public static final field event Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceType;
 	public static final field navigation Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingSourceType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -42357,6 +42419,7 @@ public final class org/hildan/chrome/devtools/domains/storage/AttributionReporti
 
 public final class org/hildan/chrome/devtools/domains/storage/AttributionReportingTriggerDataMatching : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingTriggerDataMatching$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingTriggerDataMatching;
 	public static final field exact Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingTriggerDataMatching;
 	public static final field modulus Lorg/hildan/chrome/devtools/domains/storage/AttributionReportingTriggerDataMatching;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -43138,6 +43201,7 @@ public final class org/hildan/chrome/devtools/domains/storage/GetUsageAndQuotaRe
 
 public final class org/hildan/chrome/devtools/domains/storage/InterestGroupAccessType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAccessType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAccessType;
 	public static final field additionalBid Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAccessType;
 	public static final field additionalBidWin Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAccessType;
 	public static final field bid Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAccessType;
@@ -43160,6 +43224,7 @@ public final class org/hildan/chrome/devtools/domains/storage/InterestGroupAcces
 
 public final class org/hildan/chrome/devtools/domains/storage/InterestGroupAuctionEventType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionEventType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionEventType;
 	public static final field configResolved Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionEventType;
 	public static final field started Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionEventType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -43173,6 +43238,7 @@ public final class org/hildan/chrome/devtools/domains/storage/InterestGroupAucti
 
 public final class org/hildan/chrome/devtools/domains/storage/InterestGroupAuctionFetchType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionFetchType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionFetchType;
 	public static final field bidderJs Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionFetchType;
 	public static final field bidderTrustedSignals Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionFetchType;
 	public static final field bidderWasm Lorg/hildan/chrome/devtools/domains/storage/InterestGroupAuctionFetchType;
@@ -43676,6 +43742,7 @@ public final class org/hildan/chrome/devtools/domains/storage/SharedStorageAcces
 
 public final class org/hildan/chrome/devtools/domains/storage/SharedStorageAccessType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/SharedStorageAccessType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/SharedStorageAccessType;
 	public static final field documentAddModule Lorg/hildan/chrome/devtools/domains/storage/SharedStorageAccessType;
 	public static final field documentAppend Lorg/hildan/chrome/devtools/domains/storage/SharedStorageAccessType;
 	public static final field documentClear Lorg/hildan/chrome/devtools/domains/storage/SharedStorageAccessType;
@@ -43895,6 +43962,7 @@ public final class org/hildan/chrome/devtools/domains/storage/StorageBucketInfo$
 
 public final class org/hildan/chrome/devtools/domains/storage/StorageBucketsDurability : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/StorageBucketsDurability$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/StorageBucketsDurability;
 	public static final field relaxed Lorg/hildan/chrome/devtools/domains/storage/StorageBucketsDurability;
 	public static final field strict Lorg/hildan/chrome/devtools/domains/storage/StorageBucketsDurability;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -44012,6 +44080,7 @@ public final class org/hildan/chrome/devtools/domains/storage/StorageDomain {
 
 public final class org/hildan/chrome/devtools/domains/storage/StorageType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/storage/StorageType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/storage/StorageType;
 	public static final field all Lorg/hildan/chrome/devtools/domains/storage/StorageType;
 	public static final field appcache Lorg/hildan/chrome/devtools/domains/storage/StorageType;
 	public static final field cache_storage Lorg/hildan/chrome/devtools/domains/storage/StorageType;
@@ -44978,6 +45047,7 @@ public final class org/hildan/chrome/devtools/domains/systeminfo/ImageDecodeAcce
 
 public final class org/hildan/chrome/devtools/domains/systeminfo/ImageType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/systeminfo/ImageType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/systeminfo/ImageType;
 	public static final field jpeg Lorg/hildan/chrome/devtools/domains/systeminfo/ImageType;
 	public static final field unknown Lorg/hildan/chrome/devtools/domains/systeminfo/ImageType;
 	public static final field webp Lorg/hildan/chrome/devtools/domains/systeminfo/ImageType;
@@ -45052,6 +45122,7 @@ public final class org/hildan/chrome/devtools/domains/systeminfo/Size$Companion 
 
 public final class org/hildan/chrome/devtools/domains/systeminfo/SubsamplingFormat : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/systeminfo/SubsamplingFormat$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/systeminfo/SubsamplingFormat;
 	public static final field yuv420 Lorg/hildan/chrome/devtools/domains/systeminfo/SubsamplingFormat;
 	public static final field yuv422 Lorg/hildan/chrome/devtools/domains/systeminfo/SubsamplingFormat;
 	public static final field yuv444 Lorg/hildan/chrome/devtools/domains/systeminfo/SubsamplingFormat;
@@ -47054,6 +47125,7 @@ public final class org/hildan/chrome/devtools/domains/webaudio/AudioParam$Compan
 
 public final class org/hildan/chrome/devtools/domains/webaudio/AutomationRate : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webaudio/AutomationRate$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webaudio/AutomationRate;
 	public static final field aRate Lorg/hildan/chrome/devtools/domains/webaudio/AutomationRate;
 	public static final field kRate Lorg/hildan/chrome/devtools/domains/webaudio/AutomationRate;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -47107,6 +47179,7 @@ public final class org/hildan/chrome/devtools/domains/webaudio/BaseAudioContext$
 
 public final class org/hildan/chrome/devtools/domains/webaudio/ChannelCountMode : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webaudio/ChannelCountMode$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webaudio/ChannelCountMode;
 	public static final field clampedMax Lorg/hildan/chrome/devtools/domains/webaudio/ChannelCountMode;
 	public static final field explicit Lorg/hildan/chrome/devtools/domains/webaudio/ChannelCountMode;
 	public static final field max Lorg/hildan/chrome/devtools/domains/webaudio/ChannelCountMode;
@@ -47121,6 +47194,7 @@ public final class org/hildan/chrome/devtools/domains/webaudio/ChannelCountMode$
 
 public final class org/hildan/chrome/devtools/domains/webaudio/ChannelInterpretation : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webaudio/ChannelInterpretation$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webaudio/ChannelInterpretation;
 	public static final field discrete Lorg/hildan/chrome/devtools/domains/webaudio/ChannelInterpretation;
 	public static final field speakers Lorg/hildan/chrome/devtools/domains/webaudio/ChannelInterpretation;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -47167,6 +47241,7 @@ public final class org/hildan/chrome/devtools/domains/webaudio/ContextRealtimeDa
 
 public final class org/hildan/chrome/devtools/domains/webaudio/ContextState : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webaudio/ContextState$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webaudio/ContextState;
 	public static final field closed Lorg/hildan/chrome/devtools/domains/webaudio/ContextState;
 	public static final field interrupted Lorg/hildan/chrome/devtools/domains/webaudio/ContextState;
 	public static final field running Lorg/hildan/chrome/devtools/domains/webaudio/ContextState;
@@ -47182,6 +47257,7 @@ public final class org/hildan/chrome/devtools/domains/webaudio/ContextState$Comp
 
 public final class org/hildan/chrome/devtools/domains/webaudio/ContextType : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webaudio/ContextType$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webaudio/ContextType;
 	public static final field offline Lorg/hildan/chrome/devtools/domains/webaudio/ContextType;
 	public static final field realtime Lorg/hildan/chrome/devtools/domains/webaudio/ContextType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -47782,6 +47858,7 @@ public final class org/hildan/chrome/devtools/domains/webauthn/AddVirtualAuthent
 
 public final class org/hildan/chrome/devtools/domains/webauthn/AuthenticatorProtocol : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorProtocol$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorProtocol;
 	public static final field ctap2 Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorProtocol;
 	public static final field u2f Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorProtocol;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
@@ -47795,6 +47872,7 @@ public final class org/hildan/chrome/devtools/domains/webauthn/AuthenticatorProt
 
 public final class org/hildan/chrome/devtools/domains/webauthn/AuthenticatorTransport : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorTransport$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorTransport;
 	public static final field ble Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorTransport;
 	public static final field cable Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorTransport;
 	public static final field internal Lorg/hildan/chrome/devtools/domains/webauthn/AuthenticatorTransport;
@@ -47891,6 +47969,7 @@ public final class org/hildan/chrome/devtools/domains/webauthn/Credential$Compan
 
 public final class org/hildan/chrome/devtools/domains/webauthn/Ctap2Version : java/lang/Enum {
 	public static final field Companion Lorg/hildan/chrome/devtools/domains/webauthn/Ctap2Version$Companion;
+	public static final field UNDEFINED Lorg/hildan/chrome/devtools/domains/webauthn/Ctap2Version;
 	public static final field ctap2_0 Lorg/hildan/chrome/devtools/domains/webauthn/Ctap2Version;
 	public static final field ctap2_1 Lorg/hildan/chrome/devtools/domains/webauthn/Ctap2Version;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionSha256Sum=7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/protocol-generator/cdp-kotlin-generator/src/main/kotlin/org/hildan/chrome/devtools/protocol/generator/DomainTypesGenerator.kt
+++ b/protocol-generator/cdp-kotlin-generator/src/main/kotlin/org/hildan/chrome/devtools/protocol/generator/DomainTypesGenerator.kt
@@ -1,49 +1,112 @@
 package org.hildan.chrome.devtools.protocol.generator
 
 import com.squareup.kotlinpoet.*
-import kotlinx.serialization.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonTransformingSerializer
 import org.hildan.chrome.devtools.protocol.model.ChromeDPDomain
 import org.hildan.chrome.devtools.protocol.model.ChromeDPType
 import org.hildan.chrome.devtools.protocol.model.DomainTypeDeclaration
 import org.hildan.chrome.devtools.protocol.names.Annotations
+import org.hildan.chrome.devtools.protocol.names.ExtDeclarations
+import org.hildan.chrome.devtools.protocol.names.UndefinedEnumEntryName
 
 fun ChromeDPDomain.createDomainTypesFileSpec(): FileSpec =
     FileSpec.builder(packageName = names.packageName, fileName = names.typesFilename).apply {
         addAnnotation(Annotations.suppressWarnings)
-        types.forEach { addDomainType(it) }
+        types.forEach { addDomainType(it, experimentalDomain = experimental) }
     }.build()
 
-private fun FileSpec.Builder.addDomainType(typeDeclaration: DomainTypeDeclaration) {
+private fun FileSpec.Builder.addDomainType(typeDeclaration: DomainTypeDeclaration, experimentalDomain: Boolean) {
     when (val type = typeDeclaration.type) {
         is ChromeDPType.Object -> addType(typeDeclaration.toDataClassTypeSpec(type))
-        is ChromeDPType.Enum -> addType(typeDeclaration.toEnumTypeSpec(type))
+        is ChromeDPType.Enum -> addType(typeDeclaration.toEnumTypeSpec(type, experimentalDomain))
         is ChromeDPType.NamedRef -> addTypeAlias(typeDeclaration.toTypeAliasSpec(type))
     }
 }
 
 private fun DomainTypeDeclaration.toDataClassTypeSpec(type: ChromeDPType.Object): TypeSpec =
-    TypeSpec.classBuilder(names.declaredName).apply {
+    TypeSpec.classBuilder(names.className).apply {
         addModifiers(KModifier.DATA)
-        addCommonConfig(this@toDataClassTypeSpec)
+        addKDocAndStabilityAnnotations(element = this@toDataClassTypeSpec)
+        addAnnotation(Annotations.serializable)
         addPrimaryConstructorProps(type.properties)
     }.build()
 
-private fun DomainTypeDeclaration.toEnumTypeSpec(type: ChromeDPType.Enum): TypeSpec =
-    TypeSpec.enumBuilder(names.declaredName).apply {
-        addCommonConfig(this@toEnumTypeSpec)
+private fun DomainTypeDeclaration.toEnumTypeSpec(type: ChromeDPType.Enum, experimentalDomain: Boolean): TypeSpec =
+    TypeSpec.enumBuilder(names.className).apply {
+        addKDocAndStabilityAnnotations(element = this@toEnumTypeSpec)
         type.enumValues.forEach {
-            val enumValueKotlinName = it.dashesToCamelCase()
-            val serialNameAnnotation = AnnotationSpec.builder(SerialName::class).addMember("%S", it).build()
-            addEnumConstant(enumValueKotlinName, TypeSpec.anonymousClassBuilder().addAnnotation(serialNameAnnotation).build())
+            addEnumConstant(
+                name = it.dashesToCamelCase(),
+                typeSpec = TypeSpec.anonymousClassBuilder().addAnnotation(Annotations.serialName(it)).build()
+            )
+        }
+        if (experimental || experimentalDomain) {
+            require(type.enumValues.none { it.equals(UndefinedEnumEntryName, ignoreCase = true) }) {
+                "Cannot synthesize the '$UndefinedEnumEntryName' value for experimental enum " +
+                    "${names.declaredName} (of domain ${names.domain.domainName}) because it clashes with an " +
+                    "existing value (case-insensitive). Values:\n - ${type.enumValues.joinToString("\n - ")}"
+            }
+            addEnumConstant(
+                name = UndefinedEnumEntryName,
+                typeSpec = TypeSpec.anonymousClassBuilder()
+                    .addKdoc("This extra enum entry represents values returned by Chrome that were not defined in " +
+                                 "the protocol (for instance new values that were added later).")
+                    .build(),
+            )
+
+            // see https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#extending-the-behavior-of-the-plugin-generated-serializer
+            val enumSerializer = serializerForEnumWithUnknown(names.className, type.enumValues)
+            addType(enumSerializer)
+
+            val serializerClass = names.className.nestedClass(enumSerializer.name!!)
+            addAnnotation(Annotations.serializableWith(serializerClass))
+            addAnnotation(Annotations.keepGeneratedSerializer)
+        } else {
+            addAnnotation(Annotations.serializable)
         }
     }.build()
 
 private fun String.dashesToCamelCase(): String = replace(Regex("""-(\w)""")) { it.groupValues[1].uppercase() }
 
-private fun TypeSpec.Builder.addCommonConfig(domainTypeDeclaration: DomainTypeDeclaration) {
-    addKDocAndStabilityAnnotations(domainTypeDeclaration)
-    addAnnotation(Annotations.serializable)
-}
+private fun serializerForEnumWithUnknown(enumClass: ClassName, enumValues: List<String>): TypeSpec =
+    TypeSpec.objectBuilder("SerializerWithUnknown").apply {
+        addModifiers(KModifier.INTERNAL)
+        superclass(JsonTransformingSerializer::class.asClassName().parameterizedBy(enumClass))
+        addSuperclassConstructorParameter("%T.generatedSerializer()", enumClass)
+        addProperty(knownValuesProperty(enumValues))
+        addFunction(FunSpec.builder("transformDeserialize").apply {
+            addModifiers(KModifier.OVERRIDE)
+            addParameter("element", JsonElement::class)
+            returns(JsonElement::class)
+            addStatement("val jsonValue = element.%M.content", ExtDeclarations.Serialization.jsonPrimitiveExtension)
+            addStatement(
+                format = "return if (jsonValue in knownValues) element else %M(%S)",
+                ExtDeclarations.Serialization.JsonPrimitiveFactory,
+                UndefinedEnumEntryName,
+            )
+        }.build())
+        addFunction(FunSpec.builder("transformSerialize").apply {
+            addModifiers(KModifier.OVERRIDE)
+            addParameter("element", JsonElement::class)
+            returns(JsonElement::class)
+            addStatement("val jsonValue = element.%M.content", ExtDeclarations.Serialization.jsonPrimitiveExtension)
+            addStatement(
+                format = "require(jsonValue in knownValues) { %S }",
+                "Cannot serialize the '$UndefinedEnumEntryName' enum value placeholder for $enumClass. " +
+                    "Please use use one of the following valid values instead: $enumValues",
+            )
+            addStatement("return element")
+        }.build())
+    }.build()
+
+private fun knownValuesProperty(values: List<String>): PropertySpec =
+    PropertySpec.builder("knownValues", SET.parameterizedBy(String::class.asTypeName())).apply {
+        addModifiers(KModifier.INTERNAL)
+        val format = List(values.size) { "%S" }.joinToString(separator = ", ", prefix = "setOf(", postfix = ")")
+        initializer(format = format, *values.toTypedArray())
+    }.build()
 
 private fun DomainTypeDeclaration.toTypeAliasSpec(type: ChromeDPType.NamedRef): TypeAliasSpec =
     TypeAliasSpec.builder(names.declaredName, type.typeName).apply {

--- a/protocol-generator/cdp-kotlin-generator/src/main/kotlin/org/hildan/chrome/devtools/protocol/names/ExternalDeclarations.kt
+++ b/protocol-generator/cdp-kotlin-generator/src/main/kotlin/org/hildan/chrome/devtools/protocol/names/ExternalDeclarations.kt
@@ -4,6 +4,9 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.MemberName.Companion.member
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KeepGeneratedSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.hildan.chrome.devtools.protocol.json.*
 
@@ -35,11 +38,25 @@ object ExtDeclarations {
     fun targetInterface(target: TargetType): ClassName = ClassName(targetsPackage, "${target.kotlinName}Target")
     fun sessionInterface(target: TargetType): ClassName = ClassName(sessionsPackage, "${target.kotlinName}Session")
     fun sessionAdapter(target: TargetType): ClassName = ClassName(sessionsPackage, "${target.kotlinName}SessionAdapter")
+
+    object Serialization {
+        val jsonPrimitiveExtension = MemberName("kotlinx.serialization.json", "jsonPrimitive")
+        val JsonPrimitiveFactory = MemberName("kotlinx.serialization.json", "JsonPrimitive")
+    }
 }
 
 object Annotations {
 
     val serializable = AnnotationSpec.builder(Serializable::class).build()
+
+    fun serialName(name: String) = AnnotationSpec.builder(SerialName::class).addMember("%S", name).build()
+
+    fun serializableWith(serializerClass: ClassName) = AnnotationSpec.builder(Serializable::class)
+        .addMember("with = %T::class", serializerClass)
+        .build()
+
+    @OptIn(ExperimentalSerializationApi::class)
+    val keepGeneratedSerializer = AnnotationSpec.builder(KeepGeneratedSerializer::class).build()
 
     val jvmOverloads = AnnotationSpec.builder(JvmOverloads::class).build()
 

--- a/protocol-generator/cdp-kotlin-generator/src/main/kotlin/org/hildan/chrome/devtools/protocol/names/Names.kt
+++ b/protocol-generator/cdp-kotlin-generator/src/main/kotlin/org/hildan/chrome/devtools/protocol/names/Names.kt
@@ -2,6 +2,12 @@ package org.hildan.chrome.devtools.protocol.names
 
 import com.squareup.kotlinpoet.ClassName
 
+/**
+ * The name of the synthetic enum entry used to represent deserialized values that are not defined in the protocol.
+ */
+// Note: 'unknown' and 'undefined' already exist in some of the enums, so we want to keep this one different
+const val UndefinedEnumEntryName = "NotDefinedInProtocol"
+
 @JvmInline
 value class DomainNaming(
     val domainName: String,
@@ -48,7 +54,10 @@ sealed class NamingConvention
 data class DomainTypeNaming(
     val declaredName: String,
     val domain: DomainNaming,
-) : NamingConvention()
+) : NamingConvention() {
+    val packageName = domain.packageName
+    val className = ClassName(packageName, declaredName)
+}
 
 data class CommandNaming(
     val commandName: String,

--- a/src/jvmTest/kotlin/IntegrationTests.kt
+++ b/src/jvmTest/kotlin/IntegrationTests.kt
@@ -1,6 +1,8 @@
 import kotlinx.coroutines.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
+import org.hildan.chrome.devtools.domains.accessibility.AXProperty
+import org.hildan.chrome.devtools.domains.accessibility.AXPropertyName
 import org.hildan.chrome.devtools.domains.backgroundservice.ServiceName
 import org.hildan.chrome.devtools.domains.dom.*
 import org.hildan.chrome.devtools.domains.domdebugger.DOMBreakpointType
@@ -131,6 +133,28 @@ class IntegrationTests {
             }
         }
     }
+
+    @OptIn(ExperimentalChromeApi::class)
+    @Test
+    fun test_deserialization_unknown_enum() {
+        runBlockingWithTimeout {
+            chromeDpClient().webSocket().use { browser ->
+                browser.newPage().use { page ->
+                    page.goto("http://www.google.com")
+                    val tree = page.accessibility.getFullAXTree() // just test that this doesn't fail
+
+                    assertTrue("we are no longer testing that unknown AXPropertyName values are deserialized as NotDefinedInProtocol") {
+                        tree.nodes.any { n ->
+                            n.properties.anyUndefinedName() || n.ignoredReasons.anyUndefinedName()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun List<AXProperty>?.anyUndefinedName(): Boolean =
+        this != null && this.any { it.name == AXPropertyName.NotDefinedInProtocol }
 
     @OptIn(ExperimentalChromeApi::class)
     @Test


### PR DESCRIPTION
Update Gradle Wrapper from 8.11.1 to 8.12.

Read the release notes: https://docs.gradle.org/8.12/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `8.12`
- Distribution (-bin) zip checksum: `7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03`
- Wrapper JAR Checksum: `2db75c40782f5e8ba1fc278a5574bab070adccb2d21ca5a6e5ed840888448046`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>